### PR TITLE
백엔드 <-> Azure 함수 앱(Python) 데이터  받아오고 랜더링까지 구현

### DIFF
--- a/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/controller/HomeController.java
+++ b/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/controller/HomeController.java
@@ -1,52 +1,50 @@
 package gnu.ictcontestbackend.controller;
 
-import gnu.ictcontestbackend.repository.WeatherInfoRepository;
+import gnu.ictcontestbackend.dto.WeatherPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model; // 추가
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.client.RestTemplate;
 import java.util.*;
 
 @Controller
 @RequestMapping("/gnu-weather")
-@RequiredArgsConstructor // 레포지토리 주입을 위해 필요
+@RequiredArgsConstructor
 public class HomeController {
 
-    private final WeatherInfoRepository weatherInfoRepository;
-
-    @GetMapping({"/",""})
-    public String homeRedirect() {
-        return "redirect:/gnu-weather/home"; // 리다이렉트 방식 권장
-    }
-
-    /**
-     * currentWeather (Map): 현재 날씨 정보 Map 구조
-     * laundryScore  (int): 빨래지수(점수)  빨래 추천점수
-     * drynessScpre  (int): 건조지수(점수) 건조 지수 점수로 산불 조심과 흡연 경고
-     * alertList  (List): 알람 리스트  현재는 빈 리스트만 띄운다.
-     * chartDataJson  (String):  0,6,12,18 시 시간대별 데이터 그래프 담기
-     * @param model
-     * @return
-     */
     @GetMapping("/home")
     public String home(Model model) {
-        // 1. 현재 날씨 (에러 방지용 기본값)
-        Map<String, Object> currentWeather = new HashMap<>();
-        currentWeather.put("temp", "22");
-        currentWeather.put("skyStatus", "맑음");
-        model.addAttribute("currentWeather", currentWeather);
+        WeatherPayload data = WeatherController.latestData;
 
-        // 2. 지수 및 코멘트
-        model.addAttribute("laundryScore", 0);
-        model.addAttribute("drynessScore", 0);
+        if (data != null && data.getForecastList() != null) {
+            // 1. 대시보드 (진주 실제 온도 반영)
+            model.addAttribute("currentWeather", Map.of(
+                    "temp", data.getCurrentTemp(),
+                    "humidity", data.getCurrentReh(),
+                    "skyStatus", "경상국립대학교 실시간 기상 정보"
+            ));
 
-        // 3. 알림 리스트 (null 에러 방지를 위해 빈 리스트 생성)
-        model.addAttribute("alertList", new ArrayList<Map<String, String>>());
+            // 2. 현재 점수
+            model.addAttribute("laundryScore", (int)data.getForecastList().get(0).getLaundryScore());
+            model.addAttribute("drynessScore", (int)data.getForecastList().get(0).getDrynessScore());
 
-        // 4. 차트 데이터 초기값
-        model.addAttribute("chartDataJson", "{\"labels\":[\"0시\",\"6시\",\"12시\",\"18시\"], \"datasets\":[{\"data\":[0,0,0,0]}]}");
-
+            // 3. 24시간 Chart.js 데이터
+            Map<String, Object> chartData = new HashMap<>();
+            chartData.put("labels", data.getForecastList().stream().map(f -> f.getTime()).toList());
+            chartData.put("scores", data.getForecastList().stream().map(f -> f.getLaundryScore()).toList());
+            chartData.put("temps", data.getForecastList().stream().map(f -> f.getTemp()).toList());
+            model.addAttribute("chartDataObj", chartData);
+        } else {
+            // 데이터 수신 전 기본값
+            model.addAttribute("currentWeather", Map.of("temp", "--", "humidity", "0", "skyStatus", "수신 대기 중"));
+            model.addAttribute("laundryScore", 0);
+            model.addAttribute("drynessScore", 0);
+            model.addAttribute("chartDataObj", Map.of("labels", List.of(), "scores", List.of(), "temps", List.of()));
+        }
+        model.addAttribute("alertList", new ArrayList<>());
+        model.addAttribute("graphUrl", "https://naltongsalm1.blob.core.windows.net/graphs/weather_detail.png");
         return "home";
     }
 }

--- a/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/controller/WeatherController.java
+++ b/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/controller/WeatherController.java
@@ -1,0 +1,47 @@
+package gnu.ictcontestbackend.controller;
+
+import gnu.ictcontestbackend.domain.WeatherInfo;
+import gnu.ictcontestbackend.dto.WeatherPayload;
+import gnu.ictcontestbackend.service.WeatherInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class WeatherController {
+    private final WeatherInfoService weatherInfoService;
+    public static WeatherPayload latestData;
+
+    @PostMapping("/alerts")
+    public ResponseEntity<String> receiveAlert(@RequestBody WeatherPayload data) {
+        latestData = data;
+        if (data.getForecastList() != null && !data.getForecastList().isEmpty()) {
+            entitySave(data);
+        }
+        return ResponseEntity.ok("데이터 수신 완료");
+    }
+
+    @GetMapping("/history")
+    public List<WeatherInfo> getAllHistory() {
+        return weatherInfoService.findAll();
+    }
+
+    private void entitySave(WeatherPayload data) {
+        // 가장 첫 번째(현재 시간대) 예측 데이터를 대표로 저장
+        WeatherPayload.ForecastItem first = data.getForecastList().get(0);
+        WeatherInfo entity = WeatherInfo.builder()
+                .weatherType("INTEGRATED")
+                .message(data.getCurrentTemp() + "도 / " + data.getCurrentReh() + "%")
+                .temp(Double.parseDouble(data.getCurrentTemp()))
+                .humidity(Double.parseDouble(data.getCurrentReh()))
+                .laundryScore(first.getLaundryScore())
+                .createdAt(LocalDateTime.now())
+                .build();
+        weatherInfoService.save(entity);
+    }
+}

--- a/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/domain/WeatherInfo.java
+++ b/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/domain/WeatherInfo.java
@@ -6,26 +6,14 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Getter
-@Builder
-@RequiredArgsConstructor
-@AllArgsConstructor
+@Getter @Builder @NoArgsConstructor @AllArgsConstructor
 public class WeatherInfo {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column
     private String weatherType;
-
-    @Column
     private String message;
-
-    @Column
-    private String weatherValue;
-
-    @Column
+    private double temp;
+    private double humidity;
+    private double laundryScore;
     private LocalDateTime createdAt;
-
-
 }

--- a/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/dto/WeatherInfoRequest.java
+++ b/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/dto/WeatherInfoRequest.java
@@ -1,0 +1,7 @@
+package gnu.ictcontestbackend.dto;
+
+public record WeatherInfoRequest (
+        String weatherType,
+        String message,
+        String weatherValue
+){ }

--- a/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/dto/WeatherPayload.java
+++ b/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/dto/WeatherPayload.java
@@ -1,0 +1,19 @@
+package gnu.ictcontestbackend.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class WeatherPayload {
+    private String currentTemp;
+    private String currentReh;
+    private List<ForecastItem> forecastList;
+
+    @Data
+    public static class ForecastItem {
+        private String time;
+        private double temp;
+        private double laundryScore;
+        private double drynessScore;
+    }
+}

--- a/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/service/WeatherInfoService.java
+++ b/backend/ict-contest-backend/src/main/java/gnu/ictcontestbackend/service/WeatherInfoService.java
@@ -1,0 +1,26 @@
+package gnu.ictcontestbackend.service;
+
+import gnu.ictcontestbackend.domain.WeatherInfo;
+import gnu.ictcontestbackend.repository.WeatherInfoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class WeatherInfoService {
+    private final WeatherInfoRepository weatherInfoRepository;
+
+    @Autowired
+    public WeatherInfoService(WeatherInfoRepository weatherInfoRepository) {
+        this.weatherInfoRepository = weatherInfoRepository;
+    }
+
+    public void save(WeatherInfo weatherInfo) {
+        weatherInfoRepository.save(weatherInfo);
+    }
+
+    public List<WeatherInfo> findAll() {
+        return weatherInfoRepository.findAll();
+    }
+}

--- a/backend/ict-contest-backend/src/main/resources/static/css/home.css
+++ b/backend/ict-contest-backend/src/main/resources/static/css/home.css
@@ -58,7 +58,7 @@ body {
 /* 상단 메인 날씨 카드 (그라데이션) */
 .summary-card {
     grid-column: 1 / 2;
-    background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+    background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
     color: var(--color-card);
     display: flex;
     justify-content: space-between;
@@ -85,7 +85,7 @@ body {
 }
 
 .score-item {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.15);
     padding: 15px;
     border-radius: 15px;
 }

--- a/backend/ict-contest-backend/src/main/resources/templates/home.html
+++ b/backend/ict-contest-backend/src/main/resources/templates/home.html
@@ -1,85 +1,108 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>날통삶  날씨를 통한 나의 삶</title>
-  <link rel="stylesheet" th:href="@{/css/home.css}">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <meta charset="UTF-8">
+    <title>날통삶 - 날씨를 통한 나의 삶</title>
+    <link rel="stylesheet" th:href="@{/css/home.css}">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
 <div class="dashboard-container">
-  <aside class="sidebar">
-    <h2>날통삶</h2>
-    <nav>
-      <p>Dashboard</p>
-      <p>Forecast</p>
-      <p>Alerts</p>
-    </nav>
-  </aside>
+    <aside class="sidebar">
+        <h2>날통삶</h2>
+        <nav>
+            <p>Dashboard</p>
+            <p>Forecast</p>
+            <p>Alerts</p>
+        </nav>
+    </aside>
 
-  <main class="main-content">
-    <div class="card summary-card">
-      <div class="weather-left">
-        <h2 th:text="'오늘의 날씨'">대쉬보드 제목</h2>
-        <div class="temp-large" th:text="${currentWeather.temp} + '°'">몇 도</div>
-        <p th:text="${currentWeather.skyStatus}">날씨 정보(ex:맑음)</p>
-      </div>
-      <div class="weather-right">
-        <div class="scores">
-          <div class="score-item">
-            <span>🧺 빨래지수</span>
-            <strong th:text="${laundryScore} + '점'">85</strong>
-          </div>
-          <div class="score-item">
-            <span>🔥 건조지수</span>
-            <strong th:text="${drynessScore} + '점'">45</strong>
-          </div>
+    <main class="main-content">
+        <div class="card summary-card">
+            <div class="weather-left">
+                <h2 style="font-weight: 600; opacity: 0.9;">실시간 기상 대시보드</h2>
+                <div class="temp-large" th:text="${currentWeather.temp} + '°'">--°</div>
+                <p style="font-size: 1.1rem; opacity: 0.9;" th:text="${currentWeather.skyStatus}">상태 정보</p>
+                <div style="margin-top: 15px; font-size: 0.9rem; opacity: 0.7;">
+                    습도 <span th:text="${currentWeather.humidity}">0</span>% | 기상청 공식 데이터
+                </div>
+            </div>
+            <div class="weather-right">
+                <div class="scores">
+                    <div class="score-item">🧺 빨래 <strong th:text="${laundryScore}">0</strong>점</div>
+                    <div class="score-item">🔥 건조 <strong th:text="${drynessScore}">0</strong>점</div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
 
-    <div class="card chart-card">
-      <h3>시간대별 지수 변화</h3>
-      <canvas id="trendChart" style="max-height: 300px;"></canvas>
-    </div>
+        <div class="card chart-card" style="margin-top: 25px;">
+            <h3 style="margin-bottom: 20px; font-size: 16px; color: #666;">📅 향후 24시간 예측 (1시간 단위)</h3>
+            <div style="height: 300px;">
+                <canvas id="forecastChart"></canvas>
+            </div>
+        </div>
 
-    <div class="alerts-section card">
-      <h3>알람 & 경고</h3>
-      <div th:each="alert : ${alertList}"
-           th:class="'alert-item alert-' + ${alert.type}">
-        <strong th:text="${alert.title}">제목</strong>
-        <p th:text="${alert.message}">내용</p>
-      </div>
-      <div th:if="${#lists.isEmpty(alertList)}" class="alert-item alert-success">
-        <strong>안전</strong>
-        <p>현재 특이 기상 상황이 없습니다.</p>
-      </div>
-    </div>
-  </main>
+        <div class="card detail-viz-card" style="text-align: center; padding: 20px;">
+            <h3>상세 분석 리포트</h3>
+            <button onclick="document.getElementById('vizImage').style.display='block'"
+                    style="padding: 10px 25px; background: #3498db; color: white; border: none; border-radius: 20px; cursor: pointer; font-weight: bold;">
+                Matplotlib 시각화 자세히 보기
+            </button>
+            <div id="vizImage" style="display: none; margin-top: 20px;">
+                <img th:src="${graphUrl}" alt="상세 분석 그래프" style="width: 100%; border-radius: 10px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);">
+            </div>
+        </div>
+
+        <div class="alerts-section card">
+            <h3>알람 & 경고</h3>
+            <div th:each="alert : ${alertList}" th:class="'alert-item alert-' + ${alert.type}">
+                <strong th:text="${alert.title}">제목</strong>
+                <p th:text="${alert.message}">내용</p>
+            </div>
+            <div th:if="${#lists.isEmpty(alertList)}" class="alert-item alert-success">
+                <strong>안전</strong>
+                <p>현재 특이 기상 상황이 없습니다.</p>
+            </div>
+        </div>
+    </main>
 </div>
 
 <script th:inline="javascript">
-  /*<![CDATA[*/
-  var chartDataRaw = /*[[${chartDataJson}]]*/ '{"labels":[], "datasets":[]}';
-  var chartData = JSON.parse(chartDataRaw);
+    const chartSource = [[${chartDataObj}]];
+    const ctx = document.getElementById('forecastChart').getContext('2d');
 
-  var ctx = document.getElementById('trendChart').getContext('2d');
-  new Chart(ctx, {
-    type: 'line',
-    data: chartData,
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      plugins: { legend: { display: false } },
-      scales: {
-        y: { beginAtZero: true, grid: { display: false } },
-        x: { grid: { display: false } }
-      },
-      elements: { line: { tension: 0.4 } } // 선을 부드럽게
-    }
-  });
-  /*]]>*/
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: chartSource.labels,
+            datasets: [{
+                label: '빨래지수',
+                data: chartSource.scores,
+                borderColor: '#2d82ff',
+                backgroundColor: 'rgba(45, 130, 255, 0.1)',
+                fill: true,
+                tension: 0.4,
+                pointRadius: 2
+            }, {
+                label: '예상 기온(°C)',
+                data: chartSource.temps,
+                borderColor: '#ff9f43',
+                borderDash: [5, 5],
+                fill: false,
+                tension: 0.4,
+                yAxisID: 'y1' // 온도는 별도 축 사용 가능 (선택사항)
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: { beginAtZero: true, max: 100, title: { display: true, text: '지수' } },
+                y1: { position: 'right', grid: { display: false }, title: { display: true, text: '온도(°C)' } }
+            }
+        }
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
close #3 

Python 으로 기상청 API 데이터를 활용해 전처리, 시각화를 한다.

백엔드 서버에서 Azure에 배포한 Python 기반 함수 앱으로 날씨 정보를 요청한다.

요청받은 데이터값을 백엔드 서버에서 DB에 저장과 Controller를 통해 화면에 랜더링합니다.

---

### 이미지
<img width="1877" height="825" alt="image" src="https://github.com/user-attachments/assets/560c8e21-da94-4f9c-93c3-cdc7edd3d74b" />
<img width="981" height="732" alt="image" src="https://github.com/user-attachments/assets/71631979-61dd-406a-924e-bb19bfe1b3bc" />


---

### 🚨 확인된 문제점

1. 대시보드쪽 실시간 날씨 정보가 현재 정시 기준 날씨 정보가 아님
2. matplotlib 그래프 한글 깨짐 


