### PR TITLE
fix: matplotlib X축 시간 한글 인코딩 에러 해결

### DIFF
--- a/python-data/processor.py
+++ b/python-data/processor.py
@@ -19,7 +19,7 @@ def process_weather_data(ncst_list, fcst_list):
         # 1. 빨래지수 기본 공식: (100-습도)*0.6 + (풍속*10)*0.4
         l_score = (100 - reh) * 0.6 + (wsd * 10) * 0.4
         
-        # 2. [추가됨] 밤 시간대(18시 ~ 06시) 햇빛 부재 페널티 적용
+        # 2. 밤 시간대(18시 ~ 06시) 햇빛 부재 페널티 적용
         # fcstTime 예: "1800" -> 앞 두 자리 "18"만 가져와서 정수로 변환
         fcst_hour = int(row['fcstTime'][:2])
         
@@ -29,7 +29,7 @@ def process_weather_data(ncst_list, fcst_list):
             l_score = l_score * 0.5
         
         forecast_items.append({
-            "time": row['fcstTime'][:2] + "시",
+            "time": row['fcstTime'][:2] + "h",
             "temp": float(row['TMP']),
             "laundryScore": round(l_score, 1),
             "drynessScore": 100 - reh


### PR DESCRIPTION
## 📖 연관된 이슈
close #12 

--- 
## ⚙️해결 방법

- 영문사용 '10시' -> '10h'



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 날씨 예보 시간 표시 형식이 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->